### PR TITLE
delete rename and goto hotkey and define rename and goto command.

### DIFF
--- a/autoload/xolox/luainspect.vim
+++ b/autoload/xolox/luainspect.vim
@@ -19,10 +19,6 @@ function! xolox#luainspect#auto_enable() " {{{1
   if !&diff && !exists('b:luainspect_disabled')
     " Disable easytags.vim because it doesn't play nice with luainspect.vim!
     let b:easytags_nohl = 1
-    " Define buffer local mappings for rename / goto definition features.
-    inoremap <buffer> <silent> <F2> <C-o>:call xolox#luainspect#make_request('rename')<CR>
-    nnoremap <buffer> <silent> <F2> :call xolox#luainspect#make_request('rename')<CR>
-    nnoremap <buffer> <silent> gd :call xolox#luainspect#make_request('go_to')<CR>
     " Enable balloon evaluation / dynamic tool tips.
     if has('balloon_eval')
       setlocal ballooneval balloonexpr=LuaInspectToolTip()

--- a/plugin/luainspect.vim
+++ b/plugin/luainspect.vim
@@ -55,6 +55,12 @@ command! -bar -bang LuaInspect call xolox#luainspect#highlight_cmd(<q-bang> == '
 " This command can be used as a toggle to enable/disable the highlighting.
 command! -bar LuaInspectToggle call xolox#luainspect#toggle_cmd()
 
+" This command call rename
+command! -bar LuaInspectRename call xolox#luainspect#make_request('rename')
+
+" This command goto definition features
+command! -bar LuaInspectGoto call xolox#luainspect#make_request('go_to')
+
 " Automatically enable the plug-in in Lua buffers.
 augroup PluginLuaInspect
   autocmd! FileType lua call xolox#luainspect#auto_enable()


### PR DESCRIPTION
hello. luainspect define F2 rename. rename is great!
but my gvim hotkey F2 already use ":noh" to clean search hignlight.
i recreate rename command and define hotkey in vimrc.

my vimrc define

``` VimL
"-----------------------------------------------------------------------------
" plugin - luainspect.vim
"-----------------------------------------------------------------------------
imap <F6> <C-o>:LuaInspectToggle<CR>
nmap <F6>      :LuaInspectToggle<CR>
let g:lua_inspect_warnings = 0
let g:lua_inspect_events = 'CursorHold,CursorHoldI,BufReadPost,BufWritePost'
inoremap <buffer> <silent> <F8> <C-o>:LuaInspectRename<CR>
nnoremap <buffer> <silent> <F8>      :LuaInspectRename<CR>
nnoremap <buffer> <silent> gd :LuaInspectGoto<CR>
```
