### PR TITLE
Add disable highlight group and suppress warning options

### DIFF
--- a/autoload/xolox/luainspect.vim
+++ b/autoload/xolox/luainspect.vim
@@ -215,7 +215,11 @@ function! s:highlight_variables() " {{{1
       let l2 += 0
       " These adjustments were found by trial and error :-|
       let c1 += 0
-      let c2 += 3 
+      let c2 += 3
+      if index(g:lua_inspect_disabled_highlight_groups, group) != -1
+        continue
+      endif
+      
       if group == 'luaInspectWrongArgCount'
         call matchadd(group, s:highlight_position(l1, c1, l2, c2, 0))
       elseif group == 'luaInspectSelectedVariable' 
@@ -224,6 +228,14 @@ function! s:highlight_variables() " {{{1
         let pattern = s:highlight_position(l1, c1, l2, c2, 1)
         execute 'syntax match' group '/' . pattern . '/'
       endif
+    endif
+  endfor
+endfunction
+
+function! s:is_warning_suppressed(message) " {{{1
+  for suppress_regex in g:lua_inspect_suppress_warning
+    if a:message =~ suppress_regex 
+        return 1
     endif
   endfor
 endfunction
@@ -239,7 +251,9 @@ function! s:update_warnings(warnings) " {{{1
       let linenum = fields[1] + 0
       let colnum = fields[3] + 0
       let message = join(fields[5:-1])
-      call add(list, { 'bufnr': bufnr('%'), 'lnum': linenum, 'col': colnum, 'text': message })
+      if !s:is_warning_suppressed(message)
+        call add(list, { 'bufnr': bufnr('%'), 'lnum': linenum, 'col': colnum, 'text': message })
+      endif
     endif
   endfor
   call setloclist(winnr(), list)

--- a/doc/luainspect.txt
+++ b/doc/luainspect.txt
@@ -17,6 +17,8 @@ Contents ~
   3. The |g:lua_inspect_warnings| option
   4. The |g:lua_inspect_events| option
   5. The |g:lua_inspect_internal| option
+  6. The |g:lua_inspect_disabled_highlight_groups| option
+  7. The |g:lua_inspect_suppress_warning| option
  6. Contact                                                |luainspect-contact|
  7. License                                                |luainspect-license|
  8. References                                          |luainspect-references|
@@ -208,6 +210,38 @@ you insist on running LuaInspect as an external program you can set this
 variable to false (0) in your |vimrc| script:
 >
   :let g:lua_inspect_internal = 0
+<
+-------------------------------------------------------------------------------
+The *g:lua_inspect_disabled_highlight_groups* option
+
+If you want not to turn all highlighting off, but only some highlighting group
+(unused variables group, for example) then just add the corresponding
+highlight group in this list.
+You can see what highlighting groups does plugin have in the bottom of
+>
+  /autoload/xolox/luainspect.vim
+<
+file.
+
+Note that you'll need to add luaInspect prefix for them to get it work.
+
+Here's example of usage of this option: (line breaks are just for readability)
+>
+  :let g:lua_inspect_disabled_highlighting_groups =
+  ["luaInspectGlobalUndefined", "luaInspectFieldUndefined",
+   "luaInspectLocalUnused"]
+<
+-------------------------------------------------------------------------------
+The *g:lua_inspect_suppress_warning* option
+
+The warnings, that match any of regexp in this list will be muted.
+
+If you want to mute some warning messages you can add a regexp that matches
+that message to this list.
+
+Example usage:
+>
+  :let g:lua_inspect_suppress_warning = ["^unknown global myCfunсUsedInLua"]
 <
 ===============================================================================
                                                            *luainspect-contact*

--- a/plugin/luainspect.vim
+++ b/plugin/luainspect.vim
@@ -54,6 +54,17 @@ if !exists('g:lua_inspect_internal')
   let g:lua_inspect_internal = has('lua')
 endif
 
+if !exists("g:lua_inspect_disabled_highlight_groups")
+  " The highlighting groups in this list will not be applied to text
+  " after inspection
+  let g:lua_inspect_disabled_highlight_groups = []
+endif
+
+if !exists("g:lua_inspect_suppress_warning")
+  " Warnings, that match regexps in this list will be muted
+  let g:lua_inspect_suppress_warning = []
+endif
+
 " This command enables/updates highlighting when automatic highlighting is disabled.
 command! -bar -bang LuaInspect call xolox#luainspect#highlight_cmd(<q-bang> == '!')
 


### PR DESCRIPTION
Lua is frequently used as embedded language (for example in games). The applications, that uses Lua, provides some API to it. But of course Lua Inspect doesn't know anything about it, so it thinks that here's some error.

I've added few options to give user more control - first one allows to disable some of highlighting groups without disabling whole highlighting, and second allows to mute some of warning messages using regexps.  
Personally I use it to solve the problem I described above (I disable highlighting of undeclared globals + mute warnings about API functions provided by application), but I'm sure there are more uses for that options
